### PR TITLE
Nette 3.0 + bug fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,6 @@
 			"name": "Jiří Pudil",
 			"email": "me@jiripudil.cz",
 			"homepage": "http://jiripudil.cz"
-		},
-		{
-			"name": "Pavel Gajdoš",
-			"email": "info@pavelgajdos.cz",
-			"homepage": "pavelgajdos.cz"
 		}
 	],
 	"support": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
 			"name": "Jiří Pudil",
 			"email": "me@jiripudil.cz",
 			"homepage": "http://jiripudil.cz"
+		},
+		{
+			"name": "Pavel Gajdoš",
+			"email": "info@pavelgajdos.cz",
+			"homepage": "pavelgajdos.cz"
 		}
 	],
 	"support": {
@@ -16,13 +21,13 @@
 		"issues": "https://github.com/o2ps/TotpAuthenticator/issues"
 	},
 	"require": {
-		"php": ">= 7.0.0",
-		"nette/utils": "^2.4",
+		"php": ">= 7.1",
+		"nette/utils": "~3.0",
 		"paragonie/constant_time_encoding": "^2.0"
 	},
 	"require-dev": {
-		"nette/di": "^2.4.0",
-		"nette/tester": "^2.0.0",
+		"nette/di": "~3.0",
+		"nette/tester": "^2.2",
 		"mockery/mockery": "^1.0.0"
 	},
 	"suggest": {

--- a/src/Oops/TotpAuthenticator/DI/TotpAuthenticatorExtension.php
+++ b/src/Oops/TotpAuthenticator/DI/TotpAuthenticatorExtension.php
@@ -2,6 +2,7 @@
 
 namespace Oops\TotpAuthenticator\DI;
 
+
 use Nette\DI\CompilerExtension;
 use Nette\Utils\Validators;
 use Oops\TotpAuthenticator\Security\TotpAuthenticator;
@@ -11,28 +12,29 @@ use Oops\TotpAuthenticator\Utils\TimeProvider;
 class TotpAuthenticatorExtension extends CompilerExtension
 {
 
-	private $defaults = [
-		'timeWindow' => 1,
-		'issuer' => '',
-	];
+    private $defaults = [
+        'timeWindow' => 1,
+        'issuer' => '',
+    ];
 
 
-	public function loadConfiguration()
-	{
-		$builder = $this->getContainerBuilder();
-		$config = $this->validateConfig($this->defaults);
 
-		Validators::assertField($config, 'timeWindow', 'int');
-		Validators::assertField($config, 'issuer', 'string:1..');
+    public function loadConfiguration()
+    {
+        $builder = $this->getContainerBuilder();
+        $config = $this->validateConfig($this->defaults);
 
-		$builder->addDefinition($this->prefix('timeProvider'))
-			->setClass(TimeProvider::class)
-			->setAutowired(FALSE);
+        Validators::assertField($config, 'timeWindow', 'int');
+        Validators::assertField($config, 'issuer', 'string:1..');
 
-		$builder->addDefinition($this->prefix('authenticator'))
-			->setClass(TotpAuthenticator::class, [$this->prefix('@timeProvider')])
-			->addSetup('setTimeWindow', [$config['timeWindow']])
-			->addSetup('setIssuer', [$config['issuer']]);
-	}
+        $builder->addDefinition($this->prefix('timeProvider'))
+            ->setFactory(TimeProvider::class)
+            ->setAutowired(FALSE);
+
+        $builder->addDefinition($this->prefix('authenticator'))
+            ->setFactory(TotpAuthenticator::class, [$this->prefix('@timeProvider')])
+            ->addSetup('setTimeWindow', [$config['timeWindow']])
+            ->addSetup('setIssuer', [$config['issuer']]);
+    }
 
 }

--- a/src/Oops/TotpAuthenticator/Security/TotpAuthenticator.php
+++ b/src/Oops/TotpAuthenticator/Security/TotpAuthenticator.php
@@ -42,7 +42,8 @@ class TotpAuthenticator
 
 	public function getTotpUri(string $secret, string $accountName): string
 	{
-		return "otpauth://totp/" . ($this->issuer !== NULL ? "{$this->issuer}:" : "") . "{$accountName}?secret={$secret}" . ($this->issuer !== NULL ? "&issuer={$this->issuer}" : "");
+        $issuer = $this->issuer !== NULL ? rawurlencode($this->issuer) : null;
+        return "otpauth://totp/" . ($issuer ? "$issuer:" : "") . "$accountName?secret=$secret" . ($issuer ? "&issuer=$issuer" : "");
 	}
 
 

--- a/tests/TotpAuthenticatorTests/totpSecretTest.phpt
+++ b/tests/TotpAuthenticatorTests/totpSecretTest.phpt
@@ -19,3 +19,9 @@ Assert::match(
 	'~^otpauth://totp/jiripudil\.cz:jiripudil\?secret=[A-Z2-7]{32}&issuer=jiripudil\.cz$~',
 	$googleAuthenticator->getTotpUri($googleAuthenticator->getRandomSecret(), 'jiripudil')
 );
+
+$googleAuthenticator = (new TotpAuthenticator(new TimeProvider()))->setIssuer('Great Issuer With Spaces');
+Assert::match(
+    '~^otpauth://totp/Great%20Issuer%20With%20Spaces:jiripudil\?secret=[A-Z2-7]{32}&issuer=Great%20Issuer%20With%20Spaces$~',
+    $googleAuthenticator->getTotpUri($googleAuthenticator->getRandomSecret(), 'jiripudil')
+);


### PR DESCRIPTION
Updates composer dependencies to support Nette 3.0 
Drops support for PHP 7.0 as Nette 3.0 requires PHP >= 7.1
Fixes URI in case of an issuer value containing non-alphanumeric characters